### PR TITLE
default boolean field to false

### DIFF
--- a/packages/graphql-explorer/src/schema.ts
+++ b/packages/graphql-explorer/src/schema.ts
@@ -51,7 +51,10 @@ export function getSchemaFromType(
     return yup.number().meta({ field });
   }
   if (type === g.GraphQLBoolean) {
-    return yup.bool().meta({ field });
+    return yup
+      .bool()
+      .meta({ field })
+      .default(false);
   }
   // treat all the other scalar types as string
   if (type instanceof g.GraphQLScalarType) {


### PR DESCRIPTION
this makes sense as the checkbox is unchecked to start with and will avoid the user to have to click twice to set it to false