### PR TITLE
fix resolveLazy

### DIFF
--- a/packages/graphql-explorer/src/ui/FormFields.tsx
+++ b/packages/graphql-explorer/src/ui/FormFields.tsx
@@ -11,11 +11,10 @@ interface FormFieldsProps {
   schema: yup.ObjectSchema<any>;
 }
 
-export function resolveLazy<T extends yup.Schema<any>>(schema: T): T {
-  return schema.constructor.name === 'Lazy'
-    ? // eslint-disable-next-line no-underscore-dangle
-      (schema as any)._resolve()
-    : schema;
+export function resolveLazy<T extends yup.Schema<any>>(
+  schema: T & { resolve?: (opts: any) => T },
+): T {
+  return schema.resolve ? schema.resolve({}) : schema;
 }
 
 export function isYupArray(


### PR DESCRIPTION
cannot rely on the constructor name, because it can get mangled. plus this is more explicit