### PR TITLE
don't inline mutation arguments

### DIFF
--- a/packages/graphql-explorer/src/MutationSection.tsx
+++ b/packages/graphql-explorer/src/MutationSection.tsx
@@ -37,15 +37,14 @@ function MutationSectionListItem({
             ? explorer.queryBuilder.getNestedFragment(outputType)
             : '';
 
-          const [varDefs, varAssignements] =
-            explorer.queryBuilder.serializeVariableDefinitions(
-              Object.keys(input),
-              mutation.args,
-            );
+          const vars = explorer.queryBuilder.serializeVariableDefinitions(
+            Object.keys(input),
+            mutation.args,
+          );
 
           const resp = await explorer.mutate(
-            `mutation ${varDefs} {
-              item: ${mutation.name} ${varAssignements} ${fragment}
+            `mutation ${vars.definitions} {
+              item: ${mutation.name} ${vars.assignments} ${fragment}
             }`,
             input,
           );

--- a/packages/graphql-explorer/src/MutationSection.tsx
+++ b/packages/graphql-explorer/src/MutationSection.tsx
@@ -36,12 +36,18 @@ function MutationSectionListItem({
           const fragment = g.isObjectType(outputType)
             ? explorer.queryBuilder.getNestedFragment(outputType)
             : '';
-          const itemArgs = explorer.queryBuilder.serializeArgs(input);
+
+          const [varDefs, varAssignements] =
+            explorer.queryBuilder.serializeVariableDefinitions(
+              Object.keys(input),
+              mutation.args,
+            );
 
           const resp = await explorer.mutate(
-            `mutation {
-              item: ${mutation.name} ${itemArgs} ${fragment}
+            `mutation ${varDefs} {
+              item: ${mutation.name} ${varAssignements} ${fragment}
             }`,
+            input,
           );
           return resp.item;
         }}

--- a/packages/graphql-explorer/src/ObjectSection.tsx
+++ b/packages/graphql-explorer/src/ObjectSection.tsx
@@ -77,7 +77,10 @@ function ObjectSectionField({
             input,
             fragment = explorer.queryBuilder.getFragment(fieldType),
           ) => {
-            const itemArgs = explorer.queryBuilder.serializeArgs(input);
+            const itemArgs = explorer.queryBuilder.serializeArgsInline(
+              input,
+              field.args,
+            );
 
             const resp: any = await executeQuery!(`{
                 item: ${field.name} ${itemArgs} ${fragment}

--- a/packages/graphql-explorer/src/forms/schema.ts
+++ b/packages/graphql-explorer/src/forms/schema.ts
@@ -9,14 +9,6 @@ export interface SchemaMeta {
   Component?: React.ElementType<any>;
 }
 
-export class EnumValue {
-  constructor(public value: string) {}
-
-  toString() {
-    return this.value;
-  }
-}
-
 function makeRequired(type: g.GraphQLInputType, schema: yup.BaseSchema<any>) {
   if (type instanceof g.GraphQLList) {
     // array's `required` semantic requires the array to not be empty
@@ -29,7 +21,7 @@ function makeRequired(type: g.GraphQLInputType, schema: yup.BaseSchema<any>) {
 export default class SchemaBuilder {
   inputObjectCache: Record<string, yup.ObjectSchema<any>> = {};
 
-  enumObjectCache: Record<string, EnumValue[]> = {};
+  enumObjectCache: Record<string, string[]> = {};
 
   constructor(protected config: ConfigurationInterface) {}
 
@@ -71,18 +63,13 @@ export default class SchemaBuilder {
     }
 
     if (type instanceof g.GraphQLEnumType) {
-      // the reason we us EnumValue is because during serialization, the enum
-      // values don't have quotes, like strings do, so we box it in a specific
-      // class to make sure it gets serialized properly. see `serializeInputValue`
       if (!(type.name in this.enumObjectCache)) {
-        this.enumObjectCache[type.name] = type
-          .getValues()
-          .map((e) => new EnumValue(e.value));
+        this.enumObjectCache[type.name] = type.getValues().map((e) => e.value);
       }
       return yup
         .mixed()
         .oneOf(this.enumObjectCache[type.name])
-        .meta({ field, isEnum: true });
+        .meta({ field });
     }
 
     if (type instanceof g.GraphQLList) {

--- a/packages/graphql-explorer/src/logic/QueryBuilder.ts
+++ b/packages/graphql-explorer/src/logic/QueryBuilder.ts
@@ -173,9 +173,10 @@ export default class QueryBuilder {
   serializeVariableDefinitions(
     argNames: string[],
     argDefinitions: g.GraphQLArgument[],
-  ): [string, string] {
+  ) {
     if (argNames.length === 0) {
-      return ['', ''];
+      // we need to return empty strings because empty parens are not allowed
+      return { assignements: '', definitions: '' };
     }
 
     const argsByName = keyBy(argDefinitions, (a) => a.name);
@@ -190,7 +191,10 @@ export default class QueryBuilder {
       assignments.push(`${arg}: ${varName}`);
     });
 
-    return [`(${definitions.join(', ')})`, `(${assignments.join(', ')})`];
+    return {
+      definitions: `(${definitions.join(', ')})`,
+      assignments: `(${assignments.join(', ')})`,
+    };
   }
 
   isScalarType(type: g.GraphQLNullableType) {

--- a/packages/graphql-explorer/src/logic/QueryBuilder.ts
+++ b/packages/graphql-explorer/src/logic/QueryBuilder.ts
@@ -1,8 +1,8 @@
 import * as g from 'graphql';
 import isArray from 'lodash/isArray';
 import isPlainObject from 'lodash/isPlainObject';
+import keyBy from 'lodash/keyBy';
 
-import { EnumValue } from '../forms/schema';
 import { isNode } from '../helpers';
 import { ConfigurationInterface } from './Configuration';
 
@@ -123,7 +123,11 @@ export default class QueryBuilder {
     }`;
   }
 
-  serializeInputValue(input: any): string {
+  serializeInputValue(input: any, argType: g.GraphQLInputType): string {
+    const rawArgType = g.getNamedType(argType) as g.GraphQLInputType;
+    if (g.isEnumType(rawArgType)) {
+      return input;
+    }
     if (
       typeof input === 'string' ||
       typeof input === 'number' ||
@@ -134,31 +138,59 @@ export default class QueryBuilder {
     }
     if (isArray(input)) {
       const arrayItems = input
-        .map((i) => this.serializeInputValue(i))
+        .map((i) => this.serializeInputValue(i, rawArgType))
         .join(', ');
       return `[${arrayItems}]`;
     }
     if (isPlainObject(input)) {
+      const objectFields = g.assertInputObjectType(rawArgType).getFields();
+
       const objectItems = Object.entries(input)
         .filter(([, v]) => v !== undefined)
-        .map(([k, v]) => `${k}: ${this.serializeInputValue(v)}`)
+        .map(
+          ([k, v]) =>
+            `${k}: ${this.serializeInputValue(v, objectFields[k].type)}`,
+        )
         .join(', ');
       return `{${objectItems}}`;
-    }
-    if (input instanceof EnumValue) {
-      return input.toString();
     }
 
     throw new Error(`invalid type for input: ${input}`);
   }
 
-  serializeArgs(args: Obj) {
+  serializeArgsInline(args: Obj, argDefinitions: g.GraphQLArgument[]) {
+    const argsByName = keyBy(argDefinitions, (a) => a.name);
     const serializedArgs = Object.entries(args)
       .filter(([, v]) => v !== undefined)
-      .map(([k, v]) => `${k}: ${this.serializeInputValue(v)}`)
+      .map(
+        ([k, v]) => `${k}: ${this.serializeInputValue(v, argsByName[k].type)}`,
+      )
       .join(', ');
 
     return serializedArgs && `(${serializedArgs})`;
+  }
+
+  serializeVariableDefinitions(
+    argNames: string[],
+    argDefinitions: g.GraphQLArgument[],
+  ): [string, string] {
+    if (argNames.length === 0) {
+      return ['', ''];
+    }
+
+    const argsByName = keyBy(argDefinitions, (a) => a.name);
+
+    const definitions: string[] = [];
+    const assignments: string[] = [];
+
+    argNames.forEach((arg) => {
+      const varType = argsByName[arg].type.toString();
+      const varName = `$${arg}`;
+      definitions.push(`${varName}: ${varType}`);
+      assignments.push(`${arg}: ${varName}`);
+    });
+
+    return [`(${definitions.join(', ')})`, `(${assignments.join(', ')})`];
   }
 
   isScalarType(type: g.GraphQLNullableType) {


### PR DESCRIPTION
this is a partial fix, as query arguments are still inlined. Query arguments tend to be less complicated, so there should be less occurrences of bugs there.
This PR also simplifies handling of enum fields in argument fields'